### PR TITLE
Added File Size Limitation - Issue #5

### DIFF
--- a/frontend/src/Pages/Home/Home.jsx
+++ b/frontend/src/Pages/Home/Home.jsx
@@ -24,19 +24,42 @@ function Home() {
 
   const handleFileChange = (e) => {
     const selectedFiles = Array.from(e.target.files);
+    // File Size Limit - 100 Megabytes
+    const maxFileSize = 100 * 1024 * 1024; 
+    const largeFiles = [];
+
     const unsupportedFiles = selectedFiles.filter(
-      (file) => !supportedFormats.image.includes(file.type.split("/")[1]) &&
-                !supportedFormats.pdf.includes(file.type.split("/")[1]) &&
-                !supportedFormats.video.includes(file.type.split("/")[1])
+      (file) => {
+        const fileType = file.type.split("/")[1];
+        if (!supportedFormats.image.includes(fileType) &&
+            !supportedFormats.pdf.includes(fileType) &&
+            !supportedFormats.video.includes(fileType)) {
+          return true;
+        }
+        if (file.size > maxFileSize) {
+          largeFiles.push(file.name);
+          return false;
+        }
+        return false;
+      }
     );
 
+    
     if (unsupportedFiles.length > 0) {
       setError(`Unsupported file types: ${unsupportedFiles.map(file => file.name).join(", ")}`);
       toast.error(`Unsupported file types: ${unsupportedFiles.map(file => file.name).join(", ")}`);
       return;
     }
 
-    setFiles((prevFiles) => [...prevFiles, ...selectedFiles]);
+
+
+    if (largeFiles.length > 0) {
+      setError(`File size too large: ${largeFiles.join(", ")}. Maximum allowed size is 100MB.`);
+      toast.error(`File size too large: ${largeFiles.join(", ")}. Maximum allowed size is 100MB.`);
+      return;
+    }
+
+    setFiles((prevFiles) => [...prevFiles, ...selectedFiles.filter(file => file.size <= maxFileSize)]);
     setError("");
     if (fileInputRef.current) {
       fileInputRef.current.value = "";


### PR DESCRIPTION
Hi @Dheerajjha451 ,

Good news! I’ve successfully implemented the file size limitation as outlined in issue #5.

This pull request introduces a file size limitation to prevent large file uploads for conversion. The main logic to restrict the upload has been integrated into the frontend of the app, providing users with faster feedback through toast notifications about the size limit. **The size limit is ~100MB**. I've also attached a video demonstrating the restriction, i tried to upload a **423MB** video for conversion, & as expected it triggered the limit.

https://github.com/user-attachments/assets/a3f3d2de-5185-4873-9362-41d0712566e5

**Please take your time to review the changes, and if everything looks good, feel free to merge them.**

Thanks & Regards,
@MohitBharambe

